### PR TITLE
Increment version for nuget re-release

### DIFF
--- a/EasyMonads/EasyMonads.csproj
+++ b/EasyMonads/EasyMonads.csproj
@@ -13,7 +13,7 @@
       <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
       <IncludeSymbols>True</IncludeSymbols>
       <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-      <Version>1.4.0</Version>
+      <Version>1.4.1</Version>
    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The v1.4.0 package I uploaded to NuGet contained the code for v1.3.0.

This PR just updates the package version number to match NuGet.