### PR TITLE
Add overload for DoLeftOrNeitherAsync

### DIFF
--- a/EasyMonads/Either/Either.cs
+++ b/EasyMonads/Either/Either.cs
@@ -144,6 +144,14 @@ namespace EasyMonads
          }
       }
 
+      private static void ValidateFunction<T1>(Func<T1> function)
+      {
+         if (function is null)
+         {
+            throw new ArgumentNullException(nameof(function));
+         }
+      }
+      
       private static void ValidateFunction<T1, T2>(Func<T1, T2> function)
       {
          if (function is null)
@@ -363,6 +371,24 @@ namespace EasyMonads
          if (IsNeither)
          {
             neither();
+         }
+
+         return this;
+      }
+
+      public async Task<Either<TLeft, TRight>> DoLeftOrNeitherAsync(Func<TLeft, Task> leftAsync, Func<Task> neitherAsync)
+      {
+         ValidateFunction(leftAsync);
+         ValidateFunction(neitherAsync);
+
+         if (IsLeft)
+         {
+            await leftAsync(_left!);
+         }
+
+         if (IsNeither)
+         {
+            await neitherAsync();
          }
 
          return this;

--- a/EasyMonads/Either/EitherAsyncExtensions.cs
+++ b/EasyMonads/Either/EitherAsyncExtensions.cs
@@ -52,6 +52,12 @@ namespace EasyMonads
          Either<TLeft, TRight> eitherResult = await either;
          return eitherResult.DoLeftOrNeither(left, neither);
       }
+
+      public static async Task<Either<TLeft, TRight>> DoLeftOrNeitherAsync<TLeft, TRight>(this Task<Either<TLeft, TRight>> either, Func<TLeft, Task> leftAsync, Func<Task> neitherAsync)
+      {
+         Either<TLeft, TRight> eitherResult = await either;
+         return await eitherResult.DoLeftOrNeitherAsync(leftAsync, neitherAsync);
+      }
       
       public static Task<Either<TLeft, TResult>> MapAsync<TLeft, TRight, TResult>(this Task<Either<TLeft, TRight>> either, Func<TRight, Either<TLeft, TResult>> map)
       {


### PR DESCRIPTION
Add another overload for `DoLeftOrNeitherAsync`.  This overload allows for both the `left` and `neither` options that better support async delegates in both positions.