### PR TITLE
Maybe equality and EasyMonads.Core

### DIFF
--- a/EasyMonads.Test/MaybeTests/AsyncExtensionsTests.cs
+++ b/EasyMonads.Test/MaybeTests/AsyncExtensionsTests.cs
@@ -1,10 +1,10 @@
 ﻿using NUnit.Framework;
 using System.Threading.Tasks;
 
-namespace EasyMonads.Test
+namespace EasyMonads.Test.MaybeTests
 {
    [TestFixture]
-   internal class MaybeAsyncExtensionsTests
+   internal class AsyncExtensionsTests
    {
       [Test]
       public async Task BindAsync_Matches_None()

--- a/EasyMonads.Test/MaybeTests/CoreTests.cs
+++ b/EasyMonads.Test/MaybeTests/CoreTests.cs
@@ -1,0 +1,49 @@
+using System;
+using NUnit.Framework;
+using static EasyMonads.Core;
+
+namespace EasyMonads.Test.MaybeTests
+{
+   [TestFixture]
+   internal class CoreTests
+   {
+      [Test]
+      public void Can_Implicitly_Convert_None_To_Maybe()
+      {
+         Maybe<int> maybe = None;
+         Assert.IsTrue(maybe.IsNone);
+      }
+
+      [Test]
+      public void Maybe_Constructs_Valid_Maybe()
+      {
+         var someInt = Maybe(5);
+
+         object? obj = null;
+         var noneObj = Maybe(obj);
+         var someObj = Maybe(new object());
+
+         Assert.IsTrue(someInt.IsSome);
+         Assert.IsTrue(noneObj.IsNone);
+         Assert.IsTrue(someObj.IsSome);
+      }
+
+      [Test]
+      public void Some_Constructs_Valid_Maybe_When_Value_Is_Not_Null()
+      {
+         var maybeValType = Some(1);
+         var maybeRefType = Some(new object());
+         
+         Assert.IsTrue(maybeValType.IsSome);
+         Assert.IsTrue(maybeRefType.IsSome);
+      }
+      
+      [Test]
+      public void Some_Throws_When_Value_Is_Null()
+      {
+         object? obj = null;
+
+         Assert.Throws<ArgumentNullException>(() => Some(obj));
+      }
+  }
+}

--- a/EasyMonads.Test/MaybeTests/EquatableTests.cs
+++ b/EasyMonads.Test/MaybeTests/EquatableTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using static EasyMonads.Core;
+
+namespace EasyMonads.Test.MaybeTests
+{
+   [TestFixture]
+   internal class EquatableTests
+   {
+      [Test]
+      public void Maybe_Equality_Test()
+      {
+         var someA = Maybe(42);
+         var someB = Some(42);
+         var none = Maybe<int>.None;
+
+
+         Assert.True(someA.Equals(someB));
+         Assert.True(someA == someB);
+         Assert.True(none == None);
+      }
+
+      [Test]
+      public void Maybe_Equality_Test_When_Implicitly_Converted()
+      {
+         if (Some(42) == 42)
+         {
+            Assert.Pass();
+         }
+         else
+         {
+            Assert.Fail();
+         }
+      }
+
+      [Test]
+      public void Maybe_Inequality_Test()
+      {
+         var maybeA = Maybe(42);
+         var maybeB = Some(12);
+         Maybe<int> none = None;
+         var someObj = Some(new object());
+
+         Assert.False(maybeA.Equals(maybeB));
+         Assert.True(maybeA != maybeB);
+         Assert.True(maybeA != none);
+         
+         Assert.True(maybeA != someObj);
+         Assert.False(maybeA == someObj);
+      }
+
+      [Test]
+      public void Maybe_Inequality_Test_When_Implicitly_Converted()
+      {
+         if (Some(42) != 12)
+         {
+            Assert.Pass();
+         }
+         else
+         {
+            Assert.Fail();
+         }
+      }
+
+      [Test]
+      public void Maybe_is_Truthy_or_Falsy()
+      {
+         var someInt = Maybe<int?>.FromNullable(42);
+         var noneInt = Maybe<int?>.FromNullable(null);
+         bool some = someInt;
+         bool none = noneInt;
+         
+         Assert.IsTrue(someInt);
+         Assert.IsTrue(some);
+         Assert.IsTrue(someInt == true);
+         Assert.IsTrue(noneInt != true);
+         
+         Assert.IsFalse(noneInt);
+         Assert.IsFalse(none);
+         Assert.False(someInt == false);
+         Assert.False(noneInt != false);
+         
+         Assert.IsTrue(Some(42));
+         Assert.IsTrue(Some(new object()));
+
+      }
+      
+      [Test]
+      public void Maybe_Can_Be_Hash_Key()
+      {
+         object a = new object();
+         object b = new object();
+         
+         var set = new HashSet<Maybe<object>>
+         {
+            Maybe(a),
+            Maybe(b),
+            Maybe(a)
+         };
+
+         Assert.IsTrue(2 == set.Count);
+      }
+  }
+}

--- a/EasyMonads/Maybe/Core.cs
+++ b/EasyMonads/Maybe/Core.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace EasyMonads
+{
+   public static partial class Core
+   {
+      public static Maybe.None None => EasyMonads.Maybe.None.Default;
+
+      /// <summary>
+      /// Simple factory for `Maybe` type.
+      /// </summary>
+      /// <param name="value">non-null for `Some` or null for `None`</param>
+      /// <typeparam name="T">Type held by Maybe</typeparam>
+      /// <returns>Maybe</returns>
+      public static Maybe<T> Maybe<T>(T value) => new(value);
+
+      /// <summary>
+      /// Factory for `Maybe` type when value is expected to be non-null.
+      /// </summary>
+      /// <param name="value">non-null value</param>
+      /// <typeparam name="T">Type held by Maybe</typeparam>
+      /// <returns>Maybe</returns>
+      /// <exception cref="ArgumentNullException">Thrown if value is null</exception>
+      public static Maybe<T> Some<T>(T value)
+      {
+         if (value is null)
+         {
+            throw new ArgumentNullException(nameof(value));
+         }
+
+         return new Maybe<T>(value);
+      }
+   }
+   
+   public struct Maybe
+   {
+      /// <summary>
+      /// Simple none-type for implicit conversion to typed `Maybe`.
+      /// </summary>
+      public struct None
+      {
+         internal static readonly None Default = default;
+      }
+      
+      public static Maybe<T> FromNullable<T>(T? value)
+         => new Maybe<T>(value);
+   }
+}

--- a/EasyMonads/Maybe/Maybe.cs
+++ b/EasyMonads/Maybe/Maybe.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace EasyMonads
 {
-   public readonly struct Maybe<TValue>
+   public readonly struct Maybe<TValue> : IEquatable<Maybe<TValue>>
    {
       private readonly MaybeState _state;
       private readonly TValue? _value;
@@ -300,8 +301,58 @@ namespace EasyMonads
             ? this
             : default;
       }
-
+      
       public static readonly Maybe<TValue> None = default;
       public static implicit operator Maybe<TValue>(TValue? value) => new Maybe<TValue>(value);
+      public static implicit operator Maybe<TValue>(Maybe.None _) => None;
+
+      /// <summary>
+      /// Some is Truthy
+      /// </summary>
+      public static bool operator true(Maybe<TValue> value) =>
+         value.IsSome;
+
+      /// <summary>
+      /// None is Falsy
+      /// </summary>
+      public static bool operator false(Maybe<TValue> value) =>
+         value.IsNone;
+      
+      /// <summary>
+      /// For ease of use in Boolean expressions.
+      /// </summary>
+      public static implicit operator bool(Maybe<TValue> maybe) => 
+         maybe.IsSome;
+      
+      public static bool operator ==(Maybe<TValue> lhs, Maybe<TValue> rhs) =>
+         lhs.Equals(rhs);
+
+      public static bool operator !=(Maybe<TValue> lhs, Maybe<TValue> rhs) =>
+         !lhs.Equals(rhs);
+
+      public bool Equals(Maybe<TValue> other)
+      {
+         // States differ
+         if (_state != other._state) return false;
+
+         // States are `None`
+         if (_state == MaybeState.None) return true;
+
+         // States are `Some` so compare the values
+         return EqualityComparer<TValue?>.Default.Equals(_value, other._value);
+      }
+
+      public override bool Equals(object? obj)
+      {
+         return obj is Maybe<TValue> other && Equals(other);
+      }
+
+      public override int GetHashCode()
+      {
+         var stateHash = _state.GetHashCode();
+         var valueHash = _value is null ? 0 : EqualityComparer<TValue?>.Default.GetHashCode(_value);
+
+         return HashCode.Combine(stateHash, valueHash); 
+      }
    }
 }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The reason for these "Nullable" alternatives is to support projects with \<nulla
 
 The monads supported by this library all have some default state:
 
-* Maybe\<T> => None
-* Either\<TLeft, TRight> => Neither
+* `Maybe<T> => None`
+* `Either<TLeft, TRight> => Neither`
 
 Rather than throw an exception when receiving null values, the monads you get back will just be in their default states.
 These states should already be handled by the caller - there is nothing "unsafe" about it.
@@ -56,6 +56,53 @@ int nonNullableDays = daysSinceLastAccident.GetSomeOrDefault(0);
 double daysDouble = daysSinceLastAccident.Match(
    () => 0.0,
    x => double.Parse(x));
+```
+
+Convenience functions are available in `EasyMonads.Core` for simple `Maybe<T>` construction.
+
+* `Some(value)` should be used when you expect the value to be non-null. It throws if null.
+* `None` gets implicitly converted to `Maybe<T>`
+* `Maybe(value)` constructs from a null or non-null value.
+
+```cs
+using static EasyMonads.Core;
+
+...
+    
+var answer = Some(42);              // Maybe<int> answer = 42;
+Maybe<int> nothing = None;          // var nothing = Maybe<int>.None;
+
+Maybe<object> TryFoo()
+{
+    ...
+    return None;                    // return Maybe<object>.None;
+}
+        
+object foo = GetFoo();
+var result = Maybe(foo)             // Maybe<object>.From(foo)
+
+```
+
+Maybe has equality checks, truthiness, and implicit conversions.
+
+| LHS                      | True | RHS                   | 
+|--------------------------|------|-----------------------|
+| `Some(42)`               | `==` | `42`                  |
+| `Some(42)`               | `!=` | `12`                  |
+| `Some(42)`               | `==` | `Some(42)`            |
+| `Some(42)`               | `!=` | `Some(12)`            |
+| `Some(42)`               | `!=` | `Some(new object())`  |
+| `Maybe<object> a = None` | `!=` | `Maybe<int> b = None` |
+| `Maybe<int> a = None`    | `==` | `Maybe<int> b = None` |
+
+```cs
+Maybe<object> maybe = TryFoo();
+    
+bool success = maybe;               // bool success = maybe.IsSome;
+
+if (maybe)                          // if (maybe.IsSome)
+    ...
+
 ```
 
 ### Either\<TLeft, TRight>


### PR DESCRIPTION
`EasyMonads.Core` - new static partial class for convenience functions
* `Some(value)` should be used when you expect the value to be non-null. It throws if null.
* `None` gets implicitly converted to `Maybe<T>`
* `Maybe(value)` constructs from a null or non-null value.

`Maybe<T>`
* implemented `IEquatable<T>` 
* operators for == and != 
* implicit operators for true, false, and bool
